### PR TITLE
Enable car waypoint navigation in SIL and port boat GPS logic to Python

### DIFF
--- a/libraries/V_car/Input_Files/Config.txt
+++ b/libraries/V_car/Input_Files/Config.txt
@@ -8,7 +8,7 @@
 1	 !Poll Barometer (0=off,1=on)
 0        !IMUTYPE (0=MPU,1=LSM)
 0        !Filter Constant //0 for no filtering and 1.0 for overfiltering
-2	 	 !Control System (-1=controlled by PIC,0=off all the time,1=on all the time)
+3	 	 !Control System (-1=controlled by PIC,0=off all the time,1=on all the time)
 4.66     !mass  //Actual Mass of vehicle (kg)
 0.056    !Ixx //(kg-m^2)
 0.035    !Iyy //(kg-m^2)

--- a/libraries/V_car/Input_Files/Simulation.txt
+++ b/libraries/V_car/Input_Files/Simulation.txt
@@ -1,4 +1,4 @@
-150.0 !Final Integration time
+500.0 !Final Integration time
 0.001 !Integration rate // seconds
 0.0	!Initial X Position (m) ///Sixdof Model with quaternions
 0.0	!Initial Y Position (m)

--- a/libraries/V_car/car_controller.cpp
+++ b/libraries/V_car/car_controller.cpp
@@ -37,8 +37,6 @@ void controller::loop(double currentTime,int rx_array[],MATLAB sense_matrix) {
   /*sense_matrix.disp();
   control_matrix.disp();
   PAUSE();*/
-  control_matrix.set(1,1,STICK_MAX); //full throttle debug
-  return;
 
   //I want to keep track of timeElapsed so that I can run integrators
   //and compute derivates

--- a/libraries/V_car/controller.py
+++ b/libraries/V_car/controller.py
@@ -1,71 +1,270 @@
 import numpy as np
 
+##Earth radius in meters (for haversine distance calculation)
+EARTH_RADIUS_M = 6371000.0
+
 class CONTROLLER():
 
     def __init__(self):
-        #Waypoints
-        self.wp = np.array([[-88.1755, 30.6906], [-88.1750, 30.6902], [-88.1745, 30.6906]])
-        self.wp_index = 0 #Keeps track of which waypoint is being used
-        self.wp_index_max = len(self.wp)
-        self.R = 6371*10**3 #Radius of the Earth in m
+        ##Waypoint / autopilot state
+        self.target_lat = None
+        self.target_lon = None
+        self.waypoint_active = False
+        self.arrived = False
+
+        ##Multi-waypoint mission state
+        self._mission = []          # list of (lat, lon) including return-to-start
+        self._wp_index = 0
+        self._mission_complete = False
+
+        ##Set True by loop() when RC signal is lost and failsafe autopilot takes over.
+        ##fast.py reads this to allow motor output even when ARMED is False.
+        self.failsafe_active = False
+
+        ##Autopilot tuning gains
+        ##  Kp_steer:      heading error (deg) -> steering command
+        ##                 e.g. 90 deg error * 0.008 = 0.72 (clipped to 1.0)
+        ##                 Car has a single steering servo (no differential thrust
+        ##                 like the boat), so all yaw authority comes from here.
+        ##  base_throttle: forward throttle used while navigating (0 to 1 scale)
+        ##  arrival_radius: stop navigating when within this many meters of target
+        self.Kp_steer = 0.008
+        self.base_throttle = 0.4
+        self.arrival_radius = 5.0   # meters
+
         self.NUMCONTROLS = 2
         return
 
-    def loop(self,RunTime,rcin):#,gps_llh,rpy,g,baro):
-        ##Set defaults
-        defaults = [0,0] #-1 is minimum and 0 is mid, 1 is maximum
-        color = 'Red' #default to red color if something isn't working right
+    # -------------------------------------------------------------------------
+    # WAYPOINT MANAGEMENT (ported from libraries/V_boat/controller.py)
+    # -------------------------------------------------------------------------
 
-        ##Initialize control commands
-        controls = [0,0]
+    def set_waypoint(self, lat, lon):
+        """Set the GPS coordinate the autopilot should navigate toward."""
+        self.target_lat = float(lat)
+        self.target_lon = float(lon)
+        self.waypoint_active = True
+        self.arrived = False
+        print(f'[AUTOPILOT] Waypoint set -> lat={self.target_lat:.6f}, lon={self.target_lon:.6f}')
 
-        ##Create controls commands based on input from receiver
+    def set_mission(self, waypoints, start_lat, start_lon):
+        """
+        Load an ordered list of GPS waypoints. The vehicle navigates each
+        in sequence then returns to (start_lat, start_lon).
+
+        waypoints  : list of (lat, lon) tuples — the operator-defined stops
+        start_lat  : latitude  of the return-home point (current GPS at upload)
+        start_lon  : longitude of the return-home point (current GPS at upload)
+        """
+        if not waypoints:
+            print('[AUTOPILOT] set_mission: empty waypoint list, ignored.')
+            return
+        self._mission = [(float(la), float(lo)) for la, lo in waypoints]
+        self._mission.append((float(start_lat), float(start_lon)))  # return-to-start
+        self._wp_index = 0
+        self._mission_complete = False
+        self.target_lat = self._mission[0][0]
+        self.target_lon = self._mission[0][1]
+        self.waypoint_active = True
+        self.arrived = False
+        total = len(self._mission)
+        print(f'[AUTOPILOT] Mission loaded: {total - 1} waypoint(s) + '
+              f'return to start ({start_lat:.6f}, {start_lon:.6f})')
+
+    def _advance_waypoint(self):
+        """Advance to the next waypoint in the mission, or end the mission."""
+        self._wp_index += 1
+        if self._wp_index < len(self._mission):
+            self.target_lat = self._mission[self._wp_index][0]
+            self.target_lon = self._mission[self._wp_index][1]
+            self.arrived = False
+            is_last = (self._wp_index == len(self._mission) - 1)
+            label = 'Return to Start' if is_last else f'WP {self._wp_index + 1}'
+            print(f'[AUTOPILOT] Advancing to {label}: '
+                  f'{self.target_lat:.6f}, {self.target_lon:.6f}')
+        else:
+            self.waypoint_active = False
+            self._mission_complete = True
+            self.target_lat = None
+            self.target_lon = None
+            print('[AUTOPILOT] Mission complete — returned to start.')
+
+    def clear_waypoint(self):
+        """Cancel the active waypoint or mission and stop autopilot navigation."""
+        self.waypoint_active = False
+        self.arrived = False
+        self.target_lat = None
+        self.target_lon = None
+        self._mission = []
+        self._wp_index = 0
+        self._mission_complete = False
+        print('[AUTOPILOT] Waypoint/mission cleared')
+
+    # -------------------------------------------------------------------------
+    # NAVIGATION MATH (identical to libraries/V_boat/controller.py)
+    # -------------------------------------------------------------------------
+
+    def _bearing(self, lat1, lon1, lat2, lon2):
+        """
+        Calculate compass bearing from (lat1,lon1) to (lat2,lon2).
+        Returns degrees in [0, 360) measured clockwise from true North.
+        """
+        lat1_r = np.radians(lat1)
+        lat2_r = np.radians(lat2)
+        dlon_r = np.radians(lon2 - lon1)
+
+        x = np.sin(dlon_r) * np.cos(lat2_r)
+        y = (np.cos(lat1_r) * np.sin(lat2_r)
+             - np.sin(lat1_r) * np.cos(lat2_r) * np.cos(dlon_r))
+
+        bearing_deg = np.degrees(np.arctan2(x, y))
+        return (bearing_deg + 360.0) % 360.0
+
+    def _distance(self, lat1, lon1, lat2, lon2):
+        """
+        Haversine distance between two GPS points.
+        Returns distance in meters.
+        """
+        lat1_r, lat2_r = np.radians(lat1), np.radians(lat2)
+        dlat_r = np.radians(lat2 - lat1)
+        dlon_r = np.radians(lon2 - lon1)
+
+        a = (np.sin(dlat_r / 2) ** 2
+             + np.cos(lat1_r) * np.cos(lat2_r) * np.sin(dlon_r / 2) ** 2)
+        c = 2.0 * np.arctan2(np.sqrt(a), np.sqrt(1.0 - a))
+        return EARTH_RADIUS_M * c
+
+    def _normalize_angle(self, angle):
+        """Wrap angle to [-180, 180] degrees."""
+        while angle > 180.0:
+            angle -= 360.0
+        while angle < -180.0:
+            angle += 360.0
+        return angle
+
+    # -------------------------------------------------------------------------
+    # AUTOPILOT CONTROL LAW
+    # -------------------------------------------------------------------------
+
+    def _autopilot_commands(self, gps_lat, gps_lon, heading_deg):
+        """
+        Compute [throttle, steering] commands to steer toward the waypoint.
+
+        Unlike the boat (twin motors + rudder), the car has a single drive
+        motor and one steering servo, so all yaw authority comes from the
+        steering command instead of differential thrust:
+          1. Compute bearing to waypoint and distance.
+          2. Compute heading error = bearing - current_heading (normalized).
+          3. Steering = Kp_steer * heading_error (proportional turn command)
+          4. Throttle is held at base_throttle while navigating.
+          5. If within arrival_radius, cut throttle and declare arrived.
+
+        Commands are in [-1, 1] matching the RCIO convention:
+          -1 = full reverse / full left, 0 = mid/stopped/straight, +1 = full forward / full right
+        """
+        if not self.waypoint_active or self.target_lat is None:
+            return [0, 0]
+
+        ##Reject stale / invalid GPS
+        if gps_lat == -99 or gps_lon == -99:
+            print('[AUTOPILOT] Waiting for valid GPS fix...')
+            return [0, 0]
+
+        dist = self._distance(gps_lat, gps_lon, self.target_lat, self.target_lon)
+        bearing = self._bearing(gps_lat, gps_lon, self.target_lat, self.target_lon)
+
+        ##Check arrival
+        if dist < self.arrival_radius:
+            if not self.arrived:
+                print(f'[AUTOPILOT] Arrived at waypoint! Distance = {dist:.1f} m')
+                if self._mission:
+                    ##Mission mode: advance to the next waypoint automatically
+                    self._advance_waypoint()
+                else:
+                    ##Single-waypoint mode: hold idle
+                    self.arrived = True
+            return [0, 0]
+
+        ##Heading error: positive = need to turn right, negative = need to turn left
+        heading_error = self._normalize_angle(bearing - heading_deg)
+
+        ##Steering proportional to heading error, clipped to [-1, 1]
+        steering = float(np.clip(self.Kp_steer * heading_error, -1.0, 1.0))
+        throttle = self.base_throttle
+
+        print(f'[AUTOPILOT] dist={dist:.1f}m  bearing={bearing:.1f}°  '
+              f'heading={heading_deg:.1f}°  err={heading_error:.1f}°  '
+              f'THR={throttle:.2f}  STEER={steering:.2f}')
+
+        return [throttle, steering]
+
+    # -------------------------------------------------------------------------
+    # MAIN CONTROL LOOP
+    # -------------------------------------------------------------------------
+
+    def loop(self, RunTime, rcin, gps_llh, rpy, g, baro):
+        """
+        Called every control loop iteration by fast.py.
+
+        Args:
+            RunTime  - elapsed time (seconds)
+            rcin     - RCInput object with throttlerc, rollrc, autopilot
+            gps_llh  - GPS object (uses .latitude / .longitude, -99 if no fix)
+            rpy      - current AHRS orientation [roll, pitch, yaw] (degrees)
+            g        - angular rates (unused here)
+            baro     - barometer object (unused here)
+
+        Returns:
+            controls   - [throttle, steering] commands in [-1, 1]
+            defaults   - safe defaults used when disarmed
+            color      - LED color string
+                          'Green'  = manual
+                          'Blue'   = autopilot navigating
+                          'Yellow' = autopilot idle (no waypoint / arrived)
+                          'Red'    = default / error
+        """
+        defaults = [0, 0]   #-1 is minimum and 0 is mid, 1 is maximum
+        color = 'Red'
+        controls = [0, 0]
+        self.failsafe_active = False
+
+        heading_deg = rpy[2]  # yaw from AHRS
+
+        ##RC signal lost — transmitter out of range or powered off.
+        ##If a mission is loaded, continue it so the car returns home on its own.
+        ##If no mission is active, idle the motor safely.
+        if getattr(rcin, 'signal_lost', False):
+            self.failsafe_active = True
+            if self.waypoint_active and not self.arrived:
+                print('[FAILSAFE] RC signal lost — continuing autopilot mission.')
+                color = 'Blue'
+                controls = self._autopilot_commands(gps_llh.latitude, gps_llh.longitude, heading_deg)
+            else:
+                print('[FAILSAFE] RC signal lost — no mission active, holding idle.')
+                color = 'Yellow'
+                controls = [0, 0]
+            return controls, defaults, color
+
         if rcin.autopilot < 1500:
-            #Manual control
+            ##Manual control
             color = 'Green'
             controls[0] = rcin.throttlerc
             controls[1] = rcin.rollrc
         elif rcin.autopilot > 1500:
-            #Autopilot
-            color = 'Blue'
-            controls[0] = 0
-            controls[1] = 1
-            
-        return controls,defaults,color
+            ##GPS Autopilot mode
+            if self.waypoint_active and not self.arrived:
+                color = 'Blue'
+                controls = self._autopilot_commands(gps_llh.latitude, gps_llh.longitude, heading_deg)
+            else:
+                ##No waypoint loaded or already arrived — hold idle
+                color = 'Yellow'
+                controls = [0, 0]
 
-        """
-        #Find the distance and angle from the car to the next waypoint
-        d_long = gps_llh.longitude - self.wp[self.wp_index, 0]
-        d_lat = gps_llh.latitude - self.wp[self.wp_index, 1]
-        dx = d_long * np.pi/180 * self.R
-        dy = d_lat * np.pi/180 * self.R
-        d = np.sqrt(dx**2 + dy**2) #Distance from car to waypoint
-
-        controls = [-1,0] #-1 is minimum and 0 is mid
-
-        #Compute the controller values
-        if (rcin.autopilot < 2):
-            #Manual control
-            controls[0] = rcin.throttlerc
-            controls[1] = rcin.rollrc
-        else: #Remember to test this part of code!
-            controls[0] = 0 #Throttle in the middle
-            if self.wp_index >= self.wp_index_max:
-                controls[0] = -1 #turn motors off 
-                controls[1] = 0 #set wheels to straight
-            if (d<=20): #If the distance is less than or equal to 20 m...
-                controls[1] = 1 #Turns the front wheels left
-                time.sleep(1) #Stops the car to signal it's reached its waypoint
-                self.wp_index += 1
-            else: #If the distance is greater than 20 m...
-                controls[1] = 0 #... keep the wheels straight
-
-        ##Saturation blocks
-        for i in range(0,self.NUMCONTROLS):
-            if (controls[i] < -1):
+        ##Saturation
+        for i in range(0, self.NUMCONTROLS):
+            if controls[i] < -1:
                 controls[i] = -1
-            if (controls[i] > 1):
+            if controls[i] > 1:
                 controls[i] = 1
 
-        return controls
-        """
+        return controls, defaults, color


### PR DESCRIPTION
## Summary
- Removed a leftover debug shortcut in `car_controller.cpp` that returned full throttle before the control-mode switch ever ran, which made `WaypointLoop`/`HeadingLoop`/`VelocityLoop` dead code. Set the `Config.txt` control flag to 3 (waypoint control) so the cascade actually executes, and bumped `Simulation.txt`'s integration time to 500s.
- Validated in C++ SIMONLY: the car now completes the hardcoded 4-waypoint box `(500,0)->(500,500)->(0,500)->(0,0)` twice within 500s, advancing waypoints correctly and steering toward each bearing.
- Ported the boat's GPS waypoint navigation (`libraries/V_boat/controller.py`) to `libraries/V_car/controller.py`: haversine distance, great-circle bearing, multi-waypoint mission loading with auto-advance and return-to-start, and RC-signal-lost failsafe that continues an active mission.
- The car's control law is adapted for its single motor + steering servo (no differential thrust like the boat) yaw authority comes entirely from a proportional steering command, with throttle held at a constant `base_throttle` while navigating.
- Kept the existing `loop(RunTime, rcin, gps_llh, rpy, g, baro)` signature that `src/fast.py` already calls for `VEHICLE='car'`.

## Notes
- The Python side has no SIL harness to run against, so `controller.py` was verified with a standalone smoke test using mocked RC/GPS objects (manual passthrough, idle/no-waypoint, straight-line and 90° bearing cases, mission auto-advance on arrival, RC-loss failsafe). Real-world tuning of `Kp_steer`, `base_throttle`, and `arrival_radius` will still be needed on the physical car.
- While reading `src/fast_pix.py`, noticed it calls `vehicle.loop(RunTime, rc.rcin, gps_lat=..., gps_lon=..., heading_deg=...)`, which matches the boat's `waypoint_loop()` signature, not its actual `loop()` method (still the old stub). Didn't touch that since it's outside this PR's scope, but flagging it in case it's worth a follow-up.

## Test plan
- [x] Compiled and ran `make MODEL=car simonly` in SIL (Ubuntu/WSL), confirmed the car completes the 4-waypoint box route twice in 500s with correct waypoint-advance and steering behavior.
- [x] Ran a standalone Python smoke test against `controller.py` covering manual mode, idle autopilot, straight/turning navigation, mission advance, and RC-loss failsafe.
- [ ] Field test on the physical car and tune gains (`Kp_steer`, `base_throttle`, `arrival_radius`).