### PR TITLE
Fix airplane Config.txt missing rows causing intermittent segfault

### DIFF
--- a/libraries/V_airplane/Input_Files/Config.txt
+++ b/libraries/V_airplane/Input_Files/Config.txt
@@ -13,6 +13,11 @@
 0.23083252176875	!Ixx(kg-m^2)
 0.12326181467115 	!Iyy(kg-m^2)
 0.261842767316082 	!Izz(kg-m^2)
+0	 !Ixy (kg-m^2)
+0	 !Ixz (kg-m^2)
+0	 !Iyz (kg-m^2)
+30.0	 !Override Latitude Origin (deg)
+-88.0	 !Override Longitude Origin (deg)
 
 !Note that the IMU, PWM out and control loop run as fast as possible
 !in my opinion those are the most crucial items


### PR DESCRIPTION
## Summary
While working on #54 ("Test autopilot control laws in SIL with sensor errors" for the airplane), I hit a segfault before I could even get to the sensor-errors test it crashed in plain manual mode too, so this is unrelated to that specific checklist item.

`libraries/V_airplane/Input_Files/Config.txt` only had 15 rows, but `sensors.cpp`/`modeling.cpp` read `configuration_matrix` rows up to 20 (`Ixy`/`Ixz`/`Iyz` at rows 16-18, GPS origin lat/lon override at rows 19-20) the same rows `V_car`'s `Config.txt` already has. The missing rows produced an out-of-bounds `MATLAB::get()` read on every run:
```
Error in get() command. Request Out of bounds - var = configuration_matrix
Requested Row and Column -> row = 20, col = 1
Size of Matrix = 19 1
```
Reading past the allocated buffer is undefined behavior, which explains the odd symptom: running under `gdb` happened to read harmless garbage and completed the full 200s run fine, but running the exact same binary directly segfaulted consistently in both SIMONLY and SIL, and regardless of control mode (reproduced even in plain manual/`icontrol=0`).

## Fix
Added the missing rows: zeros for the off-diagonal inertia terms, and `30.0`/`-88.0` for the GPS origin override (matching the car's origin).

## Test plan
- [x] 3 consecutive crash-free runs in SIMONLY (manual mode and waypoint mode, with sensor errors on and off)
- [x] 3 consecutive crash-free runs in SIL (OpenGL) with waypoint mode + sensor errors, confirming the airplane correctly reaches WP1 and WP2 of the 4-waypoint square with zero NaNs
- [ ] Full 4-waypoint loop needs a longer `Final Integration time` than the current 200s (each leg takes ~70-80s) happy to bump that in a follow-up once you confirm this fix looks right