### PR TITLE
Add SIMONLY to Python (#68)

### DIFF
--- a/libraries/Datalogger/datalogger.py
+++ b/libraries/Datalogger/datalogger.py
@@ -4,19 +4,24 @@ import numpy as np
 import datetime
 
 class Datalogger():
-	def __init__(self,NUMOUTPUTS):
+	def __init__(self,NUMOUTPUTS,directory=None,extension='.txt'):
 		self.number = 0
 		self.SIL = util.isSIL()
-		print('Input arguments = ',sys.argv)
-		if len(sys.argv) > 1:
-			print('Using Directory = ',sys.argv[1])
-		else:
-		    sys.exit('No input argument given for datalogging directory')
-		self.setfilename(sys.argv[1])
+		if directory is None:
+			print('Input arguments = ',sys.argv)
+			if len(sys.argv) > 1:
+				print('Using Directory = ',sys.argv[1])
+			else:
+			    sys.exit('No input argument given for datalogging directory')
+			directory = sys.argv[1]
+		self.setfilename(directory,extension)
 		self.open()
 		#create an array for data
 		self.outdata = np.zeros(NUMOUTPUTS)
 		self._write_count = 0
+
+	def writeheader(self,names):
+		self.outfile.write(','.join(names) + "\n")
 
 	def setfilename(self,directory,extension='.txt'):
 		##Use datetime name only if the system clock looks valid (year >= 2024).

--- a/libraries/Environment/environment.py
+++ b/libraries/Environment/environment.py
@@ -1,0 +1,94 @@
+import numpy as np
+
+##Minimal port of environment.cpp: only the flat-earth gravity branch
+##(Gravity_Flag==3) and the ground-contact spring/damper model, which is
+##all the car's Simulation.txt (Gravity_Flag=3, Magnetic_Flag=0) exercises.
+##EGM2008/point-mass/Sun gravity and the EMM2015 magnetic model are
+##intentionally not ported here (dead code for this vehicle) -- see the
+##plan file for why. gravitymodel()/groundcontactmodel() keep the same
+##call signature as the C++ side so a future Gravity_Flag branch can be
+##added without changing callers.
+
+GRAVITYSI = 9.81
+GEARTH = 9.80665
+GNDSTIFF = 112.0
+GNDDAMP = 50.0
+GNDCOEFF = 0.1
+
+
+def sat(x, epsilon, scalefactor):
+    """Port of mathp.cpp's sat(): saturated linear interpolation."""
+    if x > epsilon:
+        return scalefactor
+    elif x < -epsilon:
+        return -scalefactor
+    else:
+        return scalefactor * x / epsilon
+
+
+class Environment():
+    def __init__(self):
+        self.mass = 0.0
+        self.Gravity_Flag = 3
+        self.FGRAVI = np.zeros(3)
+        self.FGNDI = np.zeros(3)
+        self.MGNDI = np.zeros(3)
+
+    def setMass(self, m):
+        self.mass = m
+
+    def init(self, simulation_data):
+        ##simulation_data: flat list from input_files.read_input_file(Simulation.txt)
+        self.Gravity_Flag = int(simulation_data[16])  # row 17
+
+    def gravitymodel(self, state13):
+        ##Only Gravity_Flag == 3 (flat earth, Z-down) is implemented.
+        if self.Gravity_Flag == 3:
+            g = np.array([0.0, 0.0, GEARTH])
+        elif self.Gravity_Flag == -1:
+            g = np.zeros(3)
+        else:
+            raise NotImplementedError(
+                'environment.py only implements Gravity_Flag==3 (flat earth); '
+                'got %d' % self.Gravity_Flag)
+        self.FGRAVI = g * self.mass
+
+    def groundcontactmodel(self, state13, k):
+        z = state13[2]
+        xdot, ydot, zdot = k[0], k[1], k[2]
+        N = self.mass * GRAVITYSI
+
+        inside_earth = (self.Gravity_Flag == 3) and (z > 0)  # Z is down
+
+        if inside_earth:
+            self.FGNDI = np.array([
+                -N * GNDCOEFF * sat(xdot, 0.1, 1.0),
+                -N * GNDCOEFF * sat(ydot, 0.1, 1.0),
+                -z * GNDSTIFF - zdot * GNDDAMP,
+            ])
+            self.MGNDI = np.zeros(3)
+        else:
+            self.FGNDI = np.zeros(3)
+            self.MGNDI = np.zeros(3)
+
+
+if __name__ == '__main__':
+    env = Environment()
+    env.setMass(4.66)
+    env.init([0] * 16 + [3])  # Gravity_Flag=3 at row 17 (index 16)
+    env.gravitymodel(np.zeros(13))
+    assert np.allclose(env.FGRAVI, [0, 0, 4.66 * GEARTH])
+
+    ##A vehicle 1m below the flat ground (z>0, NED convention) with zero velocity
+    ##should get a strong upward (negative Z) restoring force.
+    state = np.zeros(13)
+    state[2] = 1.0
+    env.groundcontactmodel(state, np.zeros(13))
+    assert env.FGNDI[2] < 0, env.FGNDI
+    assert abs(env.FGNDI[2] - (-1.0 * GNDSTIFF)) < 1e-9, env.FGNDI
+
+    ##Above ground -> no contact force
+    state[2] = -1.0
+    env.groundcontactmodel(state, np.zeros(13))
+    assert np.allclose(env.FGNDI, 0)
+    print('environment.py OK')

--- a/libraries/RK4/RK4.py
+++ b/libraries/RK4/RK4.py
@@ -1,0 +1,59 @@
+import numpy as np
+
+
+class RK4():
+    """Literal port of RK4.cpp: a vehicle-agnostic 4-stage RK4 integrator.
+
+    The caller is responsible for computing the derivative vector k
+    (matching integrator.k in the C++ side) before each integrate(i) call.
+    """
+
+    def __init__(self):
+        pass
+
+    def init(self, numvars, dt):
+        self.NUMVARS = numvars
+        self.TIMESTEP = dt
+        self.State = np.zeros(numvars)
+        self.StateDel = np.zeros(numvars)
+        self.k = np.zeros(numvars)
+        self.k1 = np.zeros(numvars)
+        self.k2 = np.zeros(numvars)
+        self.k3 = np.zeros(numvars)
+        self.k4 = np.zeros(numvars)
+        self.phi = np.zeros(numvars)
+
+    def set_ICs(self, x0):
+        self.State = np.array(x0, dtype=float).copy()
+        self.StateDel = np.array(x0, dtype=float).copy()
+
+    def integrate(self, i):
+        dt = self.TIMESTEP
+        if i == 1:
+            self.k1 = self.k.copy()
+            self.StateDel = self.State + self.k1 * (dt / 2.0)
+        elif i == 2:
+            self.k2 = self.k.copy()
+            self.StateDel = self.State + self.k2 * (dt / 2.0)
+        elif i == 3:
+            self.k3 = self.k.copy()
+            self.StateDel = self.State + self.k3 * dt
+        elif i == 4:
+            self.k4 = self.k.copy()
+            self.phi = self.k1 / 6.0 + self.k2 / 3.0 + self.k3 / 3.0 + self.k4 / 6.0
+            self.State = self.State + self.phi * dt
+
+
+if __name__ == '__main__':
+    ##Integrate dx/dt = 1 (constant derivative) for 1 second, expect x(1.0) ~= 1.0
+    rk = RK4()
+    rk.init(1, 0.01)
+    rk.set_ICs([0.0])
+    t = 0.0
+    while t < 1.0 - 1e-9:
+        for i in (1, 2, 3, 4):
+            rk.k[0] = 1.0
+            rk.integrate(i)
+        t += 0.01
+    assert abs(rk.State[0] - 1.0) < 1e-6, rk.State[0]
+    print('RK4.py OK: x(1.0) =', rk.State[0])

--- a/libraries/Rotation/Rotation3.py
+++ b/libraries/Rotation/Rotation3.py
@@ -1,0 +1,74 @@
+import numpy as np
+
+##Port of Rotation3.cpp / MATLAB.cpp's quat2euler/euler2quat -- plain numpy
+##functions instead of the C++ MATLAB matrix class (numpy already gives us
+##everything that class exists to provide). Only the quaternion (type=1)
+##path of Rotation3::L321 is ported, since that's all modeling.py needs.
+
+
+def quat2euler(q0123):
+    """3-2-1 Euler angles [phi, theta, psi] (radians) from [q0,q1,q2,q3]."""
+    q0, q1, q2, q3 = q0123
+    phi = np.arctan2(2 * (q0 * q1 + q2 * q3), 1 - 2 * (q1 * q1 + q2 * q2))
+    val = 2 * (q0 * q2 - q3 * q1)
+    if abs(val) > 1.0:
+        theta = np.sign(val) * np.pi / 2.0
+    else:
+        theta = np.arcsin(val)
+    psi = np.arctan2(2 * (q0 * q3 + q1 * q2), 1 - 2 * (q2 * q2 + q3 * q3))
+    return np.array([phi, theta, psi])
+
+
+def euler2quat(ptp):
+    """[q0,q1,q2,q3] from 3-2-1 Euler angles [phi, theta, psi] (radians)."""
+    phi, theta, psi = ptp
+    cphi, sphi = np.cos(phi / 2), np.sin(phi / 2)
+    cthe, sthe = np.cos(theta / 2), np.sin(theta / 2)
+    cpsi, spsi = np.cos(psi / 2), np.sin(psi / 2)
+    q0 = cphi * cthe * cpsi + sphi * sthe * spsi
+    q1 = sphi * cthe * cpsi - cphi * sthe * spsi
+    q2 = cphi * sthe * cpsi + sphi * cthe * spsi
+    q3 = cphi * cthe * spsi - sphi * sthe * cpsi
+    return np.array([q0, q1, q2, q3])
+
+
+def quat_to_T321(q0123):
+    """Body->Inertial direction cosine matrix from [q0,q1,q2,q3]."""
+    q0, q1, q2, q3 = q0123
+    return np.array([
+        [q0**2 + q1**2 - q2**2 - q3**2, 2 * (q1 * q2 - q0 * q3), 2 * (q0 * q2 + q1 * q3)],
+        [2 * (q1 * q2 + q0 * q3), q0**2 - q1**2 + q2**2 - q3**2, 2 * (q2 * q3 - q0 * q1)],
+        [2 * (q1 * q3 - q0 * q2), 2 * (q0 * q1 + q2 * q3), q0**2 - q1**2 - q2**2 + q3**2],
+    ])
+
+
+def rotate_body_to_inertial(vec_b, q0123):
+    return quat_to_T321(q0123) @ vec_b
+
+
+def rotate_inertial_to_body(vec_i, q0123):
+    return quat_to_T321(q0123).T @ vec_i
+
+
+def quat_kinematic_derivative(q0123, pqr):
+    """dq0123/dt given current quaternion and body angular rate [p,q,r]."""
+    q0, q1, q2, q3 = q0123
+    p, q, r = pqr
+    return np.array([
+        (-p * q1 - q * q2 - r * q3) / 2.0,
+        (p * q0 + r * q2 - q * q3) / 2.0,
+        (q * q0 - r * q1 + p * q3) / 2.0,
+        (r * q0 + q * q1 - p * q2) / 2.0,
+    ])
+
+
+if __name__ == '__main__':
+    for phi, theta, psi in [(0, 0, 0), (0.1, -0.2, 0.3), (0.5, 0.4, -1.0)]:
+        q = euler2quat([phi, theta, psi])
+        back = quat2euler(q)
+        assert np.allclose(back, [phi, theta, psi], atol=1e-9), (back, [phi, theta, psi])
+    ##Body x-axis under a 90deg yaw should rotate to inertial y-axis
+    q90 = euler2quat([0, 0, np.pi / 2])
+    v = rotate_body_to_inertial(np.array([1.0, 0.0, 0.0]), q90)
+    assert np.allclose(v, [0, 1, 0], atol=1e-9), v
+    print('Rotation3.py OK')

--- a/libraries/Util/input_files.py
+++ b/libraries/Util/input_files.py
@@ -1,0 +1,34 @@
+import re
+
+##Matches C++'s Datalogger::ImportFile: every line of the file becomes one
+##row (comments/blank lines included), parsed like atof() -- leading numeric
+##token only, 0.0 if nothing numeric is found. Same convention Config.txt
+##and Simulation.txt already use ("<value>\t!comment").
+_LEADING_FLOAT = re.compile(r'^\s*[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?')
+
+
+def _atof(line):
+    m = _LEADING_FLOAT.match(line)
+    return float(m.group(0)) if m else 0.0
+
+
+def read_input_file(path):
+    """Read a Config.txt/Simulation.txt style file into a flat list of floats.
+
+    Row N (1-indexed, matching the C++ MATLAB.get(row,1) convention used
+    throughout this codebase) is data[N-1].
+    """
+    with open(path, 'r') as f:
+        return [_atof(line) for line in f]
+
+
+if __name__ == '__main__':
+    import tempfile, os
+    sample = "0.1 \t!Standard Out Print Rate\n1.0\t!Something\n!Just a comment\n\n5\n"
+    fd, tmp = tempfile.mkstemp()
+    os.write(fd, sample.encode())
+    os.close(fd)
+    data = read_input_file(tmp)
+    os.remove(tmp)
+    assert data == [0.1, 1.0, 0.0, 0.0, 5.0], data
+    print('input_files.py OK:', data)

--- a/libraries/V_car/forces.py
+++ b/libraries/V_car/forces.py
@@ -1,0 +1,61 @@
+import math
+import numpy as np
+
+##Literal port of car_forces.cpp::ForceMoment. Module named "forces" (not
+##"car_forces") so modeling.py can import it the same generic way fast.py
+##already imports a vehicle's "controller" module -- this is the seam a
+##future libraries/V_boat/forces.py plugs into for issue #69.
+
+STICK_MID = 1500.0
+STICK_MAX = 2016.0
+STICK_MIN = 992.0
+
+
+class FORCES():
+    def __init__(self):
+        self.FB = np.zeros(3)
+        self.MB = np.zeros(3)
+
+    def ForceMoment(self, time, state13, statedot13, pwm_out):
+        """pwm_out: [motor, steering] in microseconds. Returns (FB, MB), both
+        3-element numpy arrays: body-frame force (N) / moment (N-m)."""
+        motor = pwm_out[0]
+        steering = pwm_out[1]
+
+        u = state13[7]
+        v = state13[8]
+        r = state13[12]
+
+        force_max = 50.0
+        s = 0.007681
+        dpwm = motor - STICK_MID
+        dsteer = steering - STICK_MID
+        steer_angle = 45 * math.pi / 180.0 * dsteer / (STICK_MAX - STICK_MID)
+        force = math.copysign(1.0, dpwm) * force_max * (1 - math.exp(-s * abs(dpwm)))
+
+        xforce = force - 7.65 * u
+        yforce = -10.0 * v + 0.0 * steer_angle
+        Nmoment = 75 * (steer_angle - 0.4 * r)
+
+        self.FB = np.array([xforce, yforce, 0.0])
+        self.MB = np.array([0.0, 0.0, Nmoment])
+        return self.FB, self.MB
+
+
+if __name__ == '__main__':
+    f = FORCES()
+    state = np.zeros(13)
+
+    ##Motor at mid-stick (no throttle command) -> force should be ~0
+    FB, MB = f.ForceMoment(0.0, state, np.zeros(13), [STICK_MID, STICK_MID])
+    assert abs(FB[0]) < 1e-9, FB
+
+    ##Full forward throttle -> positive xforce approaching force_max as u stays 0
+    FB, MB = f.ForceMoment(0.0, state, np.zeros(13), [STICK_MAX, STICK_MID])
+    assert FB[0] > 0, FB
+    assert FB[0] < 50.0, FB
+
+    ##Full reverse throttle -> negative xforce
+    FB, MB = f.ForceMoment(0.0, state, np.zeros(13), [STICK_MIN, STICK_MID])
+    assert FB[0] < 0, FB
+    print('forces.py (car) OK')

--- a/libraries/modeling/modeling.py
+++ b/libraries/modeling/modeling.py
@@ -1,0 +1,242 @@
+import sys
+import math
+import numpy as np
+
+sys.path.append('../RK4')
+sys.path.append('../libraries/RK4')
+sys.path.append('../Rotation')
+sys.path.append('../libraries/Rotation')
+sys.path.append('../Environment')
+sys.path.append('../libraries/Environment')
+sys.path.append('../GPS')
+sys.path.append('../libraries/GPS')
+
+from RK4 import RK4
+import Rotation3 as rot
+from environment import Environment
+import gps as gps_module
+
+##Literal port of modeling.cpp's init()/loop()/rk4step()/Derivatives(),
+##minus the OpenGL/HIL-specific branches (not applicable in Python) and
+##minus its own file logging (fast_simonly.py owns the Datalogger calls,
+##since Python's Datalogger works differently from the C++ one -- see the
+##plan file). Vehicle-agnostic except for the `forces` module it imports,
+##following the same "sys.path.append('../libraries/V_'+VEHICLE)" pattern
+##fast.py already uses for `controller` -- this is the seam issue #69 plugs
+##a boat forces.py into.
+
+##Truth-row column layout (29 values, matches modeling.cpp's headernames[]
+##exactly -- quaternions replaced by Euler-in-degrees, Yaw duplicated at
+##the IMU-heading slot). Reused by sensors.py for the sensed-row headers.
+HEADERNAMES = [
+    'X(m)', 'Y(m)', 'Z(m)', 'Roll (deg)', 'Pitch (deg)', 'Yaw (deg)',
+    'U(m/s)', 'V(m/s)', 'W(m/s)', 'P(rad/s)', 'Q(rad/s)', 'R(rad/s)',
+    'Mx(Gauss)', 'My(Gauss)', 'Mz(Gauss)',
+    'GPS Latitude (deg)', 'GPS Longitude (deg)', 'GPS Altitude (m)',
+    'GPS Heading (deg)', 'Yaw (deg)',
+    'Analog 1 (V)', 'Analog 2 (V)', 'Analog 3 (V)', 'Analog 4 (V)', 'Analog 5 (V)', 'Analog 6 (V)',
+    'Pressure (Pa)', 'Pressure Altitude (m)', 'Temperature (C)',
+]
+
+OUTMIN, OUTMID, OUTMAX = 992.0, 1500.0, 1950.0
+
+
+def convert_z_to_pressure(z):
+    """Port of mathp.cpp's ConvertZ2Pressure."""
+    altitude = -z
+    pascals = 101325.0 * (1.0 - 2.25577e-5 * altitude) ** 5.25588
+    return pascals * 0.01
+
+
+class MODELING():
+    def __init__(self, vehicle):
+        self.vehicle = vehicle
+        sys.path.append('../libraries/V_' + vehicle)
+        sys.path.append('../V_' + vehicle)
+        import forces as forces_module
+        self.extforces = forces_module.FORCES()
+        self.env = Environment()
+        self.integrator = RK4()
+        self.truth_gps = gps_module.GPS()
+        self.ok = 1
+
+    def init(self, simulation_data, config_data):
+        ##simulation_data/config_data: flat lists from input_files.read_input_file()
+        self.TFINAL = simulation_data[0]        # row 1
+        self.TIMESTEP = simulation_data[1]      # row 2
+        self.integrationTime = 0.0
+
+        ##13 initial conditions: X,Y,Z,q0,q1,q2,q3,u,v,w,p,q,r (rows 3-15)
+        ic13 = simulation_data[2:15]
+
+        self.NUMACTUATORS = int(simulation_data[38])  # row 39
+        ##Settling times (rows 40..40+N-1) and actuator ICs (rows 40+N..40+2N-1)
+        settle_start = 39
+        ic_start = 39 + self.NUMACTUATORS
+        self.settling_time = simulation_data[settle_start:settle_start + self.NUMACTUATORS]
+        actuator_ic = simulation_data[ic_start:ic_start + self.NUMACTUATORS]
+
+        self.NUMINTEGRATIONSTATES = 13 + self.NUMACTUATORS
+        ic_full = list(ic13) + list(actuator_ic)
+
+        self.IACTUATORERROR = int(simulation_data[36])   # row 37
+        self.ACTUATORPERCENTERROR = simulation_data[37]  # row 38
+        self.FORCES_FLAG = int(simulation_data[15])       # row 16
+
+        self.actuatorStates = np.array(actuator_ic, dtype=float)
+        self.pwm_out = self.actuatorStates.copy()
+
+        ##Mass / inertia
+        self.mass = config_data[11]  # row 12
+        Ixx, Iyy, Izz = config_data[12], config_data[13], config_data[14]  # rows 13-15
+        Ixy, Ixz, Iyz = (config_data[15], config_data[16], config_data[17]) \
+            if len(config_data) > 17 else (0.0, 0.0, 0.0)  # rows 16-18
+        self.I = np.array([
+            [Ixx, Ixy, Ixz],
+            [Ixy, Iyy, Iyz],
+            [Ixz, Iyz, Izz],
+        ])
+        self.Iinv = np.linalg.inv(self.I)
+
+        self.env.setMass(self.mass)
+        self.env.init(simulation_data)
+
+        ##GPS origin override (rows 19-20), matching ConvertXYZ2LLH's convention
+        self.X_origin = config_data[18] if len(config_data) > 18 else 30.0
+        self.Y_origin = config_data[19] if len(config_data) > 19 else -88.0
+        self.truth_gps.setOrigin(self.X_origin, self.Y_origin)
+        self.xprev, self.yprev = 0.0, 0.0
+
+        self.integrator.init(self.NUMINTEGRATIONSTATES, self.TIMESTEP)
+        self.integrator.set_ICs(ic_full)
+
+        print('Modeling Routine initialized')
+
+    def _set_gps(self, state13):
+        X, Y, Z = state13[0], state13[1], state13[2]
+        lat, lon, alt = self.truth_gps.convertXYZ2LATLON(X, Y, Z)
+        heading = math.degrees(math.atan2(Y - self.yprev, X - self.xprev)) if (X, Y) != (self.xprev, self.yprev) else 0.0
+        self.xprev, self.yprev = X, Y
+        return lat, lon, alt, heading
+
+    def step(self, currentTime, control_pwm_us):
+        """Advance the truth state by one TIMESTEP (4-stage RK4). control_pwm_us
+        is a length-NUMACTUATORS list/array of actuator commands in microseconds."""
+        if currentTime > self.TFINAL:
+            self.ok = 0
+            return
+        for i in (1, 2, 3, 4):
+            self._derivatives(currentTime, control_pwm_us)
+            self.integrator.integrate(i)
+        self.integrationTime += self.TIMESTEP
+
+    def get_truth_row(self):
+        """Current truth state as a 29-element row matching HEADERNAMES."""
+        state = self.integrator.State
+        q0123 = state[3:7]
+        ptp = rot.quat2euler(q0123)
+        lat, lon, alt, heading = self._set_gps(state)
+        pressure = convert_z_to_pressure(state[2])
+        pressure_alt = -state[2]
+        yaw_deg = math.degrees(ptp[2])
+        return [
+            state[0], state[1], state[2],
+            math.degrees(ptp[0]), math.degrees(ptp[1]), yaw_deg,
+            state[7], state[8], state[9],
+            state[10], state[11], state[12],
+            0.0, 0.0, 0.0,  # Mx,My,Mz -- no magnetic model
+            lat, lon, alt, heading, yaw_deg,
+            0.0, 0.0, 0.0, 0.0, 0.0, 0.0,  # Analog 1-6 -- not modeled
+            pressure, pressure_alt, 0.0,  # Temperature -- not modeled
+        ]
+
+    def _derivatives(self, currentTime, control_pwm_us):
+        ##Actuator dynamics -- passthrough unless IACTUATORERROR>1 with a
+        ##nonzero settling time (car's Simulation.txt uses IACTUATORERROR=1,
+        ##i.e. passthrough; the lag branch is implemented for parity).
+        for i in range(self.NUMACTUATORS):
+            settle = self.settling_time[i]
+            if settle == 0 or self.IACTUATORERROR <= 1:
+                self.actuatorStates[i] = control_pwm_us[i]
+            else:
+                time_constant = 4.0 / settle
+                actuatorDot = time_constant * (control_pwm_us[i] - self.actuatorStates[i])
+                self.integrator.k[13 + i] = actuatorDot
+            val = int(self.actuatorStates[i]) if self.IACTUATORERROR >= 1 else self.actuatorStates[i]
+            self.pwm_out[i] = min(max(val, OUTMIN), OUTMAX)
+
+        ##Kinematics
+        state = self.integrator.StateDel
+        cg = state[0:3]
+        q0123 = state[3:7]
+        cgdotB = state[7:10]
+        pqr = state[10:13]
+
+        cgdotI = rot.rotate_body_to_inertial(cgdotB, q0123)
+        self.integrator.k[0:3] = cgdotI
+
+        dq = rot.quat_kinematic_derivative(q0123, pqr)
+        self.integrator.k[3:7] = dq
+
+        ##Environment: gravity + ground contact (magnetic field not modeled)
+        self.env.gravitymodel(state)
+        self.env.groundcontactmodel(state, self.integrator.k)
+
+        ##External forces (vehicle-specific)
+        if self.FORCES_FLAG:
+            FB, MB = self.extforces.ForceMoment(currentTime, state, self.integrator.k, self.pwm_out)
+        else:
+            FB, MB = np.zeros(3), np.zeros(3)
+
+        FTOTALI = self.env.FGRAVI.copy()
+        FGNDB = rot.rotate_inertial_to_body(self.env.FGNDI, q0123)
+        FTOTALB = rot.rotate_inertial_to_body(FTOTALI, q0123)
+        FTOTALB = FTOTALB + FGNDB
+        ##Car always adds external forces regardless of ground contact
+        ##(matches modeling.cpp's "#if defined car || tank" branch).
+        FTOTALB = FTOTALB + FB
+
+        ##Translational dynamics: uvwdot = FTOTALB/mass - pqr x cgdotB
+        Kuvw_pqr = np.cross(pqr, cgdotB)
+        uvwdot = FTOTALB / self.mass - Kuvw_pqr
+        self.integrator.k[7:10] = uvwdot
+
+        MGNDB = rot.rotate_inertial_to_body(self.env.MGNDI, q0123)
+        MTOTALB = MGNDB + MB
+
+        ##Rotational dynamics: pqrdot = Iinv * (MTOTALB - pqr x (I*pqr))
+        I_pqr = self.I @ pqr
+        pqrskew_I_pqr = np.cross(pqr, I_pqr)
+        pqrdot = self.Iinv @ (MTOTALB - pqrskew_I_pqr)
+        self.integrator.k[10:13] = pqrdot
+
+
+if __name__ == '__main__':
+    ##Constant-throttle smoke test against the car: forward speed should
+    ##converge toward a plausible steady state under xforce = force - 7.65*u.
+    sim_data = [0.0] * 45
+    sim_data[0] = 5.0     # TFINAL
+    sim_data[1] = 0.001   # TIMESTEP
+    sim_data[5] = 1.0     # q0 = 1 (level attitude)
+    sim_data[15] = 1      # FORCES_FLAG
+    sim_data[16] = 3      # Gravity_Flag = flat earth
+    sim_data[36] = 1      # IACTUATORERROR (passthrough)
+    sim_data[38] = 2      # NUMACTUATORS
+    sim_data[41] = 1500.0  # actuator IC 1 (motor)
+    sim_data[42] = 1500.0  # actuator IC 2 (steering)
+    cfg_data = [0.0] * 20
+    cfg_data[11] = 4.66   # mass
+    cfg_data[12], cfg_data[13], cfg_data[14] = 0.056, 0.035, 0.077  # Ixx,Iyy,Izz
+    cfg_data[18], cfg_data[19] = 30.0, -88.0
+
+    m = MODELING('car')
+    m.init(sim_data, cfg_data)
+    t = 0.0
+    while t < 5.0:
+        m.step(t, [2016.0, 1500.0])  # full forward throttle, straight steering
+        t += m.TIMESTEP
+    row = m.get_truth_row()
+    u_final = row[6]
+    assert u_final > 3.0, row  # should have accelerated forward substantially
+    assert abs(row[2]) < 0.5, row  # Z should stay near ground (ground contact holding it)
+    print('modeling.py OK: U(5s) =', u_final, 'Z =', row[2])

--- a/libraries/sensors/sensors.py
+++ b/libraries/sensors/sensors.py
@@ -1,0 +1,148 @@
+import sys
+import random
+
+sys.path.append('../GPS')
+sys.path.append('../libraries/GPS')
+sys.path.append('../modeling')
+sys.path.append('../libraries/modeling')
+import gps as gps_module
+
+from modeling import convert_z_to_pressure
+
+##Self-contained port of sensors.cpp's send()/poll()/populate()/pollute(),
+##taking a truth row (modeling.MODELING.get_truth_row()) in and producing a
+##sensed row out. Deliberately does NOT run libraries/AHRS/AHRS.py's Mahony
+##filter -- sensors.cpp force-seeds its AHRS state from the truth quaternion
+##(+ noise) every call anyway (orientation.ahrs.q0..q3 = polluted truth),
+##so the net effect for SIL/SIMONLY is that sensed roll/pitch/yaw are the
+##truth Euler angles plus the configured angle bias/noise. Pollution is
+##applied directly to the already-computed truth Euler angles (equivalent
+##to sensors.cpp's quat->euler->pollute->quat->[reseed AHRS]->euler round
+##trip, without needing to reimplement the AHRS class). Position/pressure/
+##gyro pollution matches sensors.cpp exactly (pollute(bias,noise) =
+##bias + uniform(-noise,noise), bias drawn once per run).
+##
+##Two independently-noised altitude channels are kept, matching the C++
+##side: GPS altitude (bias_pos/noise_pos, feeds into satellites.Z) and
+##barometer altitude (bias_pressure/noise_pressure, feeds "Sense Z(m)").
+
+HEADERNAMES = [
+    'Sense X(m)', 'Sense Y(m)', 'Sense Z(m)', 'Sense Roll (deg)', 'Sense Pitch (deg)', 'Sense Compass (deg)',
+    'Sense U(m/s)', 'Sense V(m/s)', 'Sense W(m/s)', 'Sense P(rad/s)', 'Sense Q(rad/s)', 'Sense R(rad/s)',
+    'Sense Mx(Gauss)', 'Sense My(Gauss)', 'Sense Mz(Gauss)',
+    'Sense GPS Latitude (deg)', 'Sense GPS Longitude (deg)', 'Sense GPS Altitude (m)',
+    'Sense GPS Heading (deg)', 'Sense IMU Heading (deg)',
+    'Sense Analog 1 (V)', 'Sense Analog 2 (V)', 'Sense Analog 3 (V)', 'Sense Analog 4 (V)', 'Sense Analog 5 (V)', 'Sense Analog 6 (V)',
+    'Sense Pressure (Pa)', 'Sense Pressure Altitude (m)', 'Sense Temperature (C)',
+]
+
+
+def _randnum(start, end):
+    """Port of mathp.cpp's randnum(start,end)."""
+    return random.uniform(start, end)
+
+
+class SENSORS():
+    def __init__(self):
+        self.sense_gps = gps_module.GPS()
+        self.next_gps_time = 0.0
+        self.last_gps_poll_time = None
+
+    def _setbias(self, bias, std):
+        return [bias + _randnum(-std, std) for _ in range(3)]
+
+    def init(self, config_data, simulation_data):
+        self.GPS_RATE = config_data[4]  # row 5
+
+        self.IERROR = int(simulation_data[20])  # row 21
+        bias_pos, std_pos, self.noise_pos = simulation_data[21:24]       # rows 22-24
+        bias_angle, std_angle, self.noise_angle = simulation_data[24:27]  # rows 25-27
+        bias_pressure, std_pressure, self.noise_pressure = simulation_data[27:30]  # rows 28-30
+        bias_gyro, std_gyro, self.noise_gyro = simulation_data[30:33]     # rows 31-33
+
+        self.bias_pos = self._setbias(bias_pos, std_pos)
+        self.bias_angle = self._setbias(bias_angle, std_angle)
+        self.bias_gyro = self._setbias(bias_gyro, std_gyro)
+        self.bias_pressure_val = bias_pressure + _randnum(-std_pressure, std_pressure)
+
+        X_origin = config_data[18] if len(config_data) > 18 else 30.0
+        Y_origin = config_data[19] if len(config_data) > 19 else -88.0
+        self.sense_gps.setOrigin(X_origin, Y_origin)
+
+    def pollute(self, bias, noise):
+        return bias + _randnum(-noise, noise)
+
+    def send_and_poll(self, currentTime, truth_row):
+        """truth_row: modeling.MODELING.get_truth_row() output (29 values).
+        Returns a sensed row in the same 29-value layout (HEADERNAMES)."""
+        X, Y, Z = truth_row[0], truth_row[1], truth_row[2]
+        roll, pitch, yaw = truth_row[3], truth_row[4], truth_row[5]
+        p, q, r = truth_row[9], truth_row[10], truth_row[11]
+
+        if self.IERROR:
+            Xs = X + self.pollute(self.bias_pos[0], self.noise_pos)
+            Ys = Y + self.pollute(self.bias_pos[1], self.noise_pos)
+            Zgps = Z + self.pollute(self.bias_pos[2], self.noise_pos)
+            Zbaro = Z + self.pollute(self.bias_pressure_val, self.noise_pressure)
+            roll += self.pollute(self.bias_angle[0], self.noise_angle)
+            pitch += self.pollute(self.bias_angle[1], self.noise_angle)
+            yaw += self.pollute(self.bias_angle[2], self.noise_angle)
+            p += self.pollute(self.bias_gyro[0], self.noise_gyro)
+            q += self.pollute(self.bias_gyro[1], self.noise_gyro)
+            r += self.pollute(self.bias_gyro[2], self.noise_gyro)
+        else:
+            Xs, Ys, Zgps, Zbaro = X, Y, Z, Z
+
+        if yaw > 180:
+            yaw -= 360
+        if yaw < -180:
+            yaw += 360
+
+        if currentTime >= self.next_gps_time:
+            self.sense_gps.elapsedTime = (currentTime - self.last_gps_poll_time
+                                           if self.last_gps_poll_time is not None
+                                           else self.sense_gps.GPSNEXT)
+            lat, lon, alt = self.sense_gps.convertXYZ2LATLON(Xs, Ys, Zgps)
+            self.sense_gps.latitude, self.sense_gps.longitude, self.sense_gps.altitude = lat, lon, alt
+            self.sense_gps.compute_heading_velocity()
+            self.last_gps_poll_time = currentTime
+            self.next_gps_time = currentTime + self.GPS_RATE
+
+        speed = self.sense_gps.speed if self.sense_gps.speed != -99 else 0.0
+        gps_heading = self.sense_gps.heading if self.sense_gps.heading not in (-99, -999) else 0.0
+
+        pressure = convert_z_to_pressure(Zbaro)
+
+        return [
+            Xs, Ys, -Zbaro, roll, pitch, yaw,
+            speed, 0.0, 0.0,  # U(GPS speed), V(sideslip, not modeled), W(vertical speed, not modeled)
+            p, q, r,
+            0.0, 0.0, 0.0,  # Mx,My,Mz -- no magnetic model
+            self.sense_gps.latitude, self.sense_gps.longitude, self.sense_gps.altitude,
+            gps_heading, yaw,  # GPS heading, IMU heading (dup of polluted yaw)
+            0.0, 0.0, 0.0, 0.0, 0.0, 0.0,  # Analog 1-6 -- not modeled
+            pressure, -Zbaro, 0.0,  # Pressure, Pressure Altitude, Temperature
+        ]
+
+
+if __name__ == '__main__':
+    import numpy as np
+    s = SENSORS()
+    sim_data = [0.0] * 33
+    sim_data[20] = 1     # IERROR on
+    sim_data[21:24] = [2.0, 0.5, 1.0]   # bias/std/noise pos
+    sim_data[24:27] = [0.5, 0.5, 0.5]   # bias/std/noise angle
+    sim_data[27:30] = [2.0, 2.0, 0.5]   # bias/std/noise pressure
+    sim_data[30:33] = [0.05, 0.1, 0.1]  # bias/std/noise gyro
+    cfg_data = [0.0] * 20
+    cfg_data[4] = 1.0  # GPS_RATE
+    cfg_data[18], cfg_data[19] = 30.0, -88.0
+    s.init(cfg_data, sim_data)
+
+    truth = [0.0] * 29
+    truth[15], truth[16], truth[17] = 30.0, -88.0, 0.0  # not used directly (recomputed from X,Y)
+    sensed = s.send_and_poll(0.0, truth)
+    assert len(sensed) == 29
+    ##Position bias/noise should have moved X/Y away from exactly 0
+    assert sensed[0] != 0.0 or sensed[1] != 0.0
+    print('sensors.py OK:', sensed[:3])

--- a/plot_simonly.py
+++ b/plot_simonly.py
@@ -1,0 +1,93 @@
+#!/usr/bin/python3
+"""Standalone plotting script for the Python SIMONLY driver (src/fast_simonly.py).
+
+Adapted from plot_simulation_data.py's CSV-reading/plotting body (column
+indices carry over unchanged -- data/0.csv and logs/0.csv have the same
+column layout as the C++ side). Unlike plot_simulation_data.py this does
+NOT depend on the external pdf.py/sixdof.py (Python.git, not vendored in
+this repo) -- it uses matplotlib's built-in PdfPages directly, and does not
+compile/run any C++ executable (that scaffolding doesn't apply here).
+
+Usage: python3 plot_simonly.py [data_csv] [logs_csv]
+Defaults to the most recently written CSV in data/ and logs/.
+"""
+import sys
+import os
+import glob
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.backends.backend_pdf import PdfPages
+
+
+def latest_csv(directory):
+    files = glob.glob(os.path.join(directory, '*.csv'))
+    if not files:
+        sys.exit('No CSV files found in %s' % directory)
+    return max(files, key=os.path.getmtime)
+
+
+data_path = sys.argv[1] if len(sys.argv) > 1 else latest_csv('data')
+logs_path = sys.argv[2] if len(sys.argv) > 2 else latest_csv('logs')
+print('Sensed (data) file:', data_path)
+print('Truth  (logs) file:', logs_path)
+
+datafile = open(data_path, 'r')
+logfile = open(logs_path, 'r')
+dataheaders = datafile.readline().split(',')
+logheaders = logfile.readline().split(',')
+numVars = len(logheaders)
+print('Number of Vars =', numVars)
+
+sense_data = [ [float(x) for x in line.split(',')] for line in datafile if len(line.split(',')) > 1 ]
+model_data = [ [float(x) for x in line.split(',')] for line in logfile if len(line.split(',')) > 1 ]
+sense_data = np.array(sense_data)
+model_data = np.array(model_data)
+
+sense_time = sense_data[:, 0]
+model_time = model_data[:, 0]
+
+pdf = PdfPages('plot_simonly.pdf')
+
+for x in range(1, numVars):
+    fig = plt.figure()
+    plti = fig.add_subplot(1, 1, 1)
+    plti.plot(sense_time, sense_data[:, x], 'b', label=dataheaders[x])
+    plti.plot(model_time, model_data[:, x], 'y', label=logheaders[x])
+    plti.set_xlabel('Time (sec)')
+    plti.set_ylabel(dataheaders[x])
+    plti.grid()
+    plti.legend()
+    plti.get_yaxis().get_major_formatter().set_useOffset(False)
+    plti.get_xaxis().get_major_formatter().set_useOffset(False)
+    plt.gcf().subplots_adjust(left=0.18)
+    pdf.savefig(fig)
+    plt.close(fig)
+
+##XY trajectory
+fig = plt.figure()
+plti = fig.add_subplot(1, 1, 1)
+plti.plot(sense_data[:, 1], sense_data[:, 2], 'b', label='Sense')
+plti.plot(model_data[:, 1], model_data[:, 2], 'y', label='Model')
+plti.set_xlabel('X (m)')
+plti.set_ylabel('Y (m)')
+plti.grid()
+plti.legend()
+plt.gcf().subplots_adjust(left=0.18)
+pdf.savefig(fig)
+plt.close(fig)
+
+##Lat/Lon trajectory (columns 16/17, matching the C++ column contract)
+fig = plt.figure()
+plti = fig.add_subplot(1, 1, 1)
+plti.plot(sense_data[:, 16], sense_data[:, 17], 'b', label='Sense')
+plti.plot(model_data[:, 16], model_data[:, 17], 'y', label='Model')
+plti.set_xlabel('Latitude (deg)')
+plti.set_ylabel('Longitude (deg)')
+plti.grid()
+plti.legend()
+plt.gcf().subplots_adjust(left=0.18)
+pdf.savefig(fig)
+plt.close(fig)
+
+pdf.close()
+print('Wrote plot_simonly.pdf')

--- a/src/fast_simonly.py
+++ b/src/fast_simonly.py
@@ -1,0 +1,132 @@
+#############################################
+#
+#  FASTCASSTPy SIMONLY - fixed-timestep 6DOF physics simulation driver
+#
+#  Issue #68: fast.py only supported AUTO (real-hardware) mode. This is a
+#  separate driver (not a mode flag inside fast.py) that mirrors fast.cpp's
+#  SIMONLY loop structure instead: fixed-step clock, a truth physics engine
+#  (libraries/modeling/modeling.py) feeding a noisy sense layer
+#  (libraries/sensors/sensors.py), running the *unmodified* vehicle
+#  controller against the sensed state, and logging both a truth and a
+#  sensed CSV trail (logs/N.csv, data/N.csv) for plot_simonly.py.
+#
+#  Vinicius da Luz, Summer 2026
+#
+################################################
+
+import sys
+import types
+import numpy as np
+
+VEHICLE = 'car'
+
+sys.path.append('../libraries/Util')
+sys.path.append('../libraries/RK4')
+sys.path.append('../libraries/Rotation')
+sys.path.append('../libraries/Environment')
+sys.path.append('../libraries/modeling')
+sys.path.append('../libraries/sensors')
+sys.path.append('../libraries/GPS')
+sys.path.append('../libraries/Datalogger')
+sys.path.append('../libraries/V_' + VEHICLE)
+
+import input_files
+import modeling
+import sensors
+import controller
+import datalogger
+
+STICK_MIN, STICK_MID, STICK_MAX = 992.0, 1500.0, 2016.0
+
+
+def controls_to_pwm_us(controls):
+    """Car controller returns [throttle, steering] in [-1,1]; convert to
+    actuator PWM microseconds, matching car_forces.py's STICK_* convention."""
+    pwm = []
+    for c in controls:
+        c = max(-1.0, min(1.0, c))
+        if c >= 0:
+            pwm.append(STICK_MID + c * (STICK_MAX - STICK_MID))
+        else:
+            pwm.append(STICK_MID + c * (STICK_MID - STICK_MIN))
+    return pwm
+
+
+def main():
+    print('FASTCASST SIMONLY (Python) -- vehicle =', VEHICLE)
+
+    simulation_data = input_files.read_input_file('../libraries/V_' + VEHICLE + '/Input_Files/Simulation.txt')
+    config_data = input_files.read_input_file('../libraries/V_' + VEHICLE + '/Input_Files/Config.txt')
+
+    model = modeling.MODELING(VEHICLE)
+    model.init(simulation_data, config_data)
+
+    sense = sensors.SENSORS()
+    sense.init(config_data, simulation_data)
+
+    vehicle = controller.CONTROLLER()
+
+    ##Real telemetry-triggered mission wiring is issue #69's job -- this is
+    ##verification-only scaffolding, matching the box route used to validate
+    ##the C++ SIL/SIMONLY car controller earlier in this project.
+    start_lat, start_lon, _ = model.truth_gps.convertXYZ2LATLON(0.0, 0.0, 0.0)
+    box_waypoints = []
+    for X, Y in [(500.0, 0.0), (500.0, 500.0), (0.0, 500.0)]:
+        lat, lon, _ = model.truth_gps.convertXYZ2LATLON(X, Y, 0.0)
+        box_waypoints.append((lat, lon))
+    vehicle.set_mission(box_waypoints, start_lat, start_lon)
+
+    ##Minimal RC stub -- bypasses RCInput.py's SIL ms/us unit bug (flagged
+    ##as a follow-up, not fixed here). autopilot>1500 forces the car
+    ##controller's GPS-autopilot branch regardless of any real receiver.
+    rc_stub = types.SimpleNamespace(autopilot=1600.0, throttlerc=0.0, rollrc=0.0, signal_lost=False)
+
+    LOGRATE = config_data[1]  # row 2
+    TIMESTEP = simulation_data[1]  # row 2
+    TFINAL = simulation_data[0]  # row 1
+    NUMACTUATORS = int(simulation_data[38])
+
+    rc_names = ['RC Channel #%d' % i for i in range(1, 6)]
+    pwm_names = ['PWM Model %d' % i for i in range(1, NUMACTUATORS + 1)]
+    header = ['Time (sec)'] + modeling.HEADERNAMES + rc_names + pwm_names
+    sense_header = ['Time (sec)'] + sensors.HEADERNAMES + rc_names + pwm_names
+
+    sense_logger = datalogger.Datalogger(len(header), directory='../data/', extension='.csv')
+    sense_logger.writeheader(sense_header)
+    truth_logger = datalogger.Datalogger(len(header), directory='../logs/', extension='.csv')
+    truth_logger.writeheader(header)
+
+    rc_placeholder = [992, 1500, 1500, 1500, 992]
+
+    currentTime = 0.0
+    nextLogTime = 0.0
+    while currentTime <= TFINAL:
+        truth_row = model.get_truth_row()
+        sensed_row = sense.send_and_poll(currentTime, truth_row)
+
+        gps_llh = types.SimpleNamespace(latitude=sensed_row[15], longitude=sensed_row[16])
+        rpy_ahrs = [sensed_row[3], sensed_row[4], sensed_row[19]]
+        gdegs = sensed_row[9:12]
+
+        controls, defaults, color = vehicle.loop(currentTime, rc_stub, gps_llh, rpy_ahrs, gdegs, None)
+        pwm_us = controls_to_pwm_us(controls)
+
+        if currentTime >= nextLogTime:
+            sense_logger.outdata = [currentTime] + sensed_row + rc_placeholder + list(model.pwm_out)
+            sense_logger.println()
+            truth_logger.outdata = [currentTime] + truth_row + rc_placeholder + list(model.pwm_out)
+            truth_logger.println()
+            nextLogTime = currentTime + LOGRATE
+
+        model.step(currentTime, pwm_us)
+        if not model.ok:
+            break
+        currentTime += TIMESTEP
+
+    sense_logger.close()
+    truth_logger.close()
+    print('Main Loop End')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
Closes the first item of #69's checklist ("Add SIMONLY to Python", tracked separately as #68). `src/fast.py` only supported AUTO mode  a real-hardware polling loop with no state vector, no integration, no fixed timestep so autopilot control laws couldn't be tested without the physical vehicle.

Added a separate driver, `src/fast_simonly.py`, that ports the C++ SIMONLY architecture (`fast.cpp` + `libraries/modeling` + `libraries/sensors`) rather than retrofitting `fast.py`'s flat hardware-polling script this mirrors how the C++ side itself branches on `#ifdef SIMONLY` instead of sharing a code path with AUTO.

**New modules** (each a literal port of its C++ counterpart's formulas, verified against the actual source line-by-line):
- `libraries/RK4/RK4.py` vehicle-agnostic 4-stage RK4 integrator
- `libraries/Rotation/Rotation3.py` quaternion↔Euler, quaternion→DCM, quaternion kinematics. **Does not reuse `libraries/AHRS/AHRS.py`** its Euler convention and Mahony-filter approach don't match how `sensors.cpp` applies bias/noise directly to Euler angles.
- `libraries/Environment/environment.py` flat-earth gravity + ground-contact spring/damper (only the branches the car's `Simulation.txt` exercises; EGM2008/magnetic modeling intentionally not ported dead code for this vehicle).
- `libraries/V_car/forces.py` `car_forces.cpp`'s thrust/cornering model, named generically (`forces`, not `car_forces`) so a future `libraries/V_boat/forces.py` can plug into `modeling.py` the same way `fast.py` already imports a vehicle's `controller` module. This is the seam #69 uses without touching this PR's code.
- `libraries/modeling/modeling.py` the 13-state RK4 physics engine tying the above together.
- `libraries/sensors/sensors.py` truth-to-sensed bias/noise injection, reusing `libraries/GPS/gps.py`'s existing XYZ↔lat/lon conversion and heading/speed filter directly instead of reimplementing them.
- `libraries/Util/input_files.py` shared `Config.txt`/`Simulation.txt` row parser (same format/row-order convention as the C++ `MATLAB.get(row,1)` calls).
- `src/fast_simonly.py` the driver: fixed-step accumulator instead of wall-clock time, runs the **unmodified** `libraries/V_car/controller.py` against the sensed state, logs two CSV trails (`data/N.csv` sensed, `logs/N.csv` truth) matching the C++ side's 37-column layout.
- `plot_simonly.py` standalone plotting script adapted from `plot_simulation_data.py`'s CSV/matplotlib body. That script can't actually run today it depends on `pdf.py`/`sixdof.py` from a separate private repo, confirmed absent here so this uses matplotlib's built-in `PdfPages` instead.

**Modified:** `libraries/Datalogger/datalogger.py` gained optional `directory=`/`extension=` constructor params (falls back to today's `sys.argv[1]`/`.txt` behavior when omitted, since SIMONLY needs two independent loggers). Verified no regression against `fast.py`'s existing usage.

## Test plan
- [x] Unit smoke tests for RK4/Rotation3/environment/forces/modeling/sensors (each module's own `__main__` block)
- [x] Full 500s run completes the car's 4-waypoint box mission (WP1→WP2→WP3→return-to-start), zero NaNs
- [x] CSV output is 37 columns as expected (`Time` + 29 state vars + 5 RC + 2 PWM)
- [x] Visual plots (compass/yaw steps, forward speed, XY and lat/lon trajectory) show a clean box shape with sensed data scattered around truth by the configured noise/bias -- consistent with the earlier C++ SIMONLY plots
- [x] `Datalogger` backward-compat verified (exact `fast.py` call pattern still produces identical output)

Boat-specific work (physics, controller wiring into `fast.py`) is #69's job and is explicitly out of scope here.